### PR TITLE
Fix AuD tabs and exercise visibility

### DIFF
--- a/aud.html
+++ b/aud.html
@@ -14,7 +14,7 @@
     <style>
         .bar { transition: all 0.3s ease-in-out; }
         .code-block { background-color: #2d3748; border-radius: 0.5rem; padding: 1rem; font-family: 'Courier New', Courier, monospace; white-space: pre-wrap; }
-        .solution-code { background-color: #1a202c; border-left: 4px solid #0891b2; padding: 1rem; margin-top: 1rem; display: none; }
+        .solution-code { background-color: #1a202c; border-left: 4px solid #0891b2; padding: 1rem; margin-top: 1rem; }
     </style>
 </head>
 <body class="text-gray-200">

--- a/css/styles.css
+++ b/css/styles.css
@@ -26,10 +26,10 @@
         }
 
         /* --- View and Section Visibility Control --- */
-        .subject-view, .content-section, .mafi-content-section, .insi-content-section {
+        .subject-view, .content-section, .mafi-content-section, .insi-content-section, .aud-content-section {
             display: none; /* Hide all views by default */
         }
-        .subject-view.active, .content-section.active, .mafi-content-section.active, .insi-content-section.active {
+        .subject-view.active, .content-section.active, .mafi-content-section.active, .insi-content-section.active, .aud-content-section.active {
             display: block; /* Show only the active view */
             animation: fadeIn 0.4s ease-out; /* Add a fade-in animation */
         }

--- a/js/aud.js
+++ b/js/aud.js
@@ -419,27 +419,19 @@ function setupAud() {
             }
         },
 
-        createCodeCompletionTask() {
-            const tasks = [
+        createCodeCompletionTasks() {
+            return [
                 {
                     title: "Aufgabe 3: Listen",
-                    description: "Vervollständigen Sie die Methode `enqueue`, welche eine Person am Ende der Warteschlange (einfach verkettete Liste ohne `ende`-Zeiger) einfügt.",
-                    code: `public void enqueue (Person p) {\n  assert (p!= null);\n  Link<Person> neu = new Link<>(p, null);\n  // TODO: Fügen Sie hier Ihre Lösung ein\n}`,
-                    solution: `public void enqueue (Person p) {\n  assert (p!= null);\n  Link<Person> neu = new Link<>(p, null);\n  if (anfang == null) {\n    anfang = neu;\n  } else {\n    Link<Person> current = anfang;\n    while (current.naechster != null) {\n      current = current.naechster;\n    }\n    current.naechster = neu;\n  }\n}`
+                    question: `<p class="mb-2">Vervollständigen Sie die Methode \`enqueue\`, welche eine Person am Ende der Warteschlange (einfach verkettete Liste ohne \`ende\`-Zeiger) einfügt.</p><div class="code-block">public void enqueue (Person p) {\n  assert (p!= null);\n  Link<Person> neu = new Link<>(p, null);\n  // TODO: Fügen Sie hier Ihre Lösung ein\n}</div>`,
+                    solution: `<div class="solution-code">public void enqueue (Person p) {\n  assert (p!= null);\n  Link<Person> neu = new Link<>(p, null);\n  if (anfang == null) {\n    anfang = neu;\n  } else {\n    Link<Person> current = anfang;\n    while (current.naechster != null) {\n      current = current.naechster;\n    }\n    current.naechster = neu;\n  }\n}</div>`
                 },
                 {
                     title: "Aufgabe 4: Binäre Suchbäume",
-                    description: "Vervollständigen Sie die Methode `maximum`, die iterativ den größten Schlüssel im Suchbaum bestimmt. Ist der Baum leer, soll -1 zurückgegeben werden.",
-                    code: `public int maximum() {\n  // TODO: Fügen Sie hier Ihre Lösung ein\n}`,
-                    solution: `public int maximum() {\n  if (wurzel == null) {\n    return -1;\n  }\n  Knoten current = wurzel;\n  while (current.rechtesKind != null) {\n    current = current.rechtesKind;\n  }\n  return current.schluessel;\n}`
+                    question: `<p class="mb-2">Vervollständigen Sie die Methode \`maximum\`, die iterativ den größten Schlüssel im Suchbaum bestimmt. Ist der Baum leer, soll -1 zurückgegeben werden.</p><div class="code-block">public int maximum() {\n  // TODO: Fügen Sie hier Ihre Lösung ein\n}</div>`,
+                    solution: `<div class="solution-code">public int maximum() {\n  if (wurzel == null) {\n    return -1;\n  }\n  Knoten current = wurzel;\n  while (current.rechtesKind != null) {\n    current = current.rechtesKind;\n  }\n  return current.schluessel;\n}</div>`
                 }
             ];
-            const item = this.getRandomElement(tasks);
-            return {
-                title: item.title,
-                question: `<p class="mb-2">${item.description}</p><div class="code-block">${item.code}</div>`,
-                solution: `<div class="solution-code">${item.solution}</div>`
-            }
         }
     };
 
@@ -448,7 +440,7 @@ function setupAud() {
         const tasks = [
             AudExerciseGenerator.createMultipleChoiceTask(),
             AudExerciseGenerator.createComplexityTask(),
-            AudExerciseGenerator.createCodeCompletionTask()
+            ...AudExerciseGenerator.createCodeCompletionTasks()
         ];
 
         tasks.forEach(task => {


### PR DESCRIPTION
## Summary
- Ensure AuD sections toggle properly via CSS
- Show both Aufgaben 3 and 4 in exercises with working solution toggle
- Remove hidden styling from code solutions so answers render

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_b_6895b2b95708832283100c306638c946