### PR TITLE
feat: add semester selection

### DIFF
--- a/css/styles.css
+++ b/css/styles.css
@@ -45,10 +45,10 @@
             border: 1px solid rgba(255, 255, 255, 0.1);
         }
         
-        .subject-card {
+        .subject-card, .semester-card {
             transition: all 0.3s ease;
         }
-        .subject-card:hover {
+        .subject-card:hover, .semester-card:hover {
             transform: translateY(-5px); /* Lift card on hover */
             box-shadow: 0 10px 25px rgba(13, 202, 240, 0.2); /* Cyan glow on hover */
         }

--- a/index.html
+++ b/index.html
@@ -15,8 +15,31 @@
 </head>
 <body class="text-gray-200">
     <div class="container mx-auto p-4 sm:p-6 lg:p-8 max-w-7xl">
+        <!-- Semester Hub View -->
+        <div id="semester-hub" class="subject-view active">
+            <header class="text-center mb-12">
+                <h1 class="text-5xl font-bold text-white">Lerntool</h1>
+                <p class="text-xl text-gray-400 mt-2">Wähle dein Semester aus</p>
+            </header>
+            <div class="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-4 gap-8">
+                <div class="semester-card card p-8 rounded-2xl shadow-2xl text-center cursor-pointer" data-semester="2">
+                    <h2 class="text-3xl font-bold text-cyan-400">Semester 2</h2>
+                </div>
+                <div class="semester-card card p-8 rounded-2xl shadow-2xl text-center cursor-pointer" data-semester="3">
+                    <h2 class="text-3xl font-bold text-cyan-400">Semester 3</h2>
+                </div>
+                <div class="semester-card card p-8 rounded-2xl shadow-2xl text-center cursor-pointer" data-semester="4">
+                    <h2 class="text-3xl font-bold text-cyan-400">Semester 4</h2>
+                </div>
+                <div class="semester-card card p-8 rounded-2xl shadow-2xl text-center cursor-pointer" data-semester="5">
+                    <h2 class="text-3xl font-bold text-cyan-400">Semester 5</h2>
+                </div>
+            </div>
+        </div>
+
         <!-- Subject Hub View -->
-        <div id="subject-hub" class="subject-view active">
+        <div id="subject-hub" class="subject-view">
+            <button class="back-button nav-button px-4 py-2 rounded mb-8">Zurück</button>
             <header class="text-center mb-12">
                 <h1 class="text-5xl font-bold text-white">Lerntool</h1>
                 <p class="text-xl text-gray-400 mt-2">Wähle dein Fach aus</p>
@@ -44,6 +67,13 @@
                     <p class="text-gray-400 mt-4 exam-countdown" data-subject-id="insi"></p>
                 </div>
             </div>
+        </div>
+
+        <!-- Coming Soon View -->
+        <div id="coming-soon" class="subject-view text-center">
+            <button class="back-button nav-button px-4 py-2 rounded mb-8">Zurück</button>
+            <h1 class="text-5xl font-bold text-white">Coming Soon</h1>
+            <p class="text-xl text-gray-400 mt-2">Inhalt für dieses Semester ist noch in Arbeit.</p>
         </div>
     </div>
 

--- a/js/aud.js
+++ b/js/aud.js
@@ -1,5 +1,6 @@
 document.addEventListener('DOMContentLoaded', function() {
     // --- GENERAL SETUP ---
+    sessionStorage.setItem('selectedSemester', '2');
     const backBtn = document.querySelector('.back-to-hub-btn');
     if (backBtn) {
         backBtn.addEventListener('click', () => {

--- a/js/ccn.js
+++ b/js/ccn.js
@@ -1,4 +1,5 @@
 document.addEventListener('DOMContentLoaded', function(){
+    sessionStorage.setItem('selectedSemester', '2');
     const backBtn = document.querySelector('.back-to-hub-btn');
     if (backBtn) backBtn.addEventListener('click', () => { window.location.href = 'index.html'; });
     setupCcn();

--- a/js/index.js
+++ b/js/index.js
@@ -15,6 +15,13 @@ document.addEventListener('DOMContentLoaded', function() {
         view.classList.add('active');
     }
 
+    const storedSemester = sessionStorage.getItem('selectedSemester');
+    if (storedSemester === '2') {
+        showView(subjectHub);
+    } else if (storedSemester && storedSemester !== '2') {
+        showView(comingSoon);
+    }
+
     function updateExamCountdowns() {
         const countdownElements = document.querySelectorAll('.exam-countdown');
         const today = new Date();
@@ -53,7 +60,9 @@ document.addEventListener('DOMContentLoaded', function() {
     document.body.addEventListener('click', function(event) {
         const semesterCard = event.target.closest('.semester-card');
         if (semesterCard) {
-            if (semesterCard.dataset.semester === '2') {
+            const semester = semesterCard.dataset.semester;
+            sessionStorage.setItem('selectedSemester', semester);
+            if (semester === '2') {
                 showView(subjectHub);
             } else {
                 showView(comingSoon);
@@ -62,6 +71,7 @@ document.addEventListener('DOMContentLoaded', function() {
         }
 
         if (event.target.closest('.back-button')) {
+            sessionStorage.removeItem('selectedSemester');
             showView(semesterHub);
             return;
         }

--- a/js/index.js
+++ b/js/index.js
@@ -6,6 +6,15 @@ document.addEventListener('DOMContentLoaded', function() {
         'aud': new Date(2025, 7, 14)
     };
 
+    const semesterHub = document.getElementById('semester-hub');
+    const subjectHub = document.getElementById('subject-hub');
+    const comingSoon = document.getElementById('coming-soon');
+
+    function showView(view) {
+        [semesterHub, subjectHub, comingSoon].forEach(v => v.classList.remove('active'));
+        view.classList.add('active');
+    }
+
     function updateExamCountdowns() {
         const countdownElements = document.querySelectorAll('.exam-countdown');
         const today = new Date();
@@ -42,6 +51,21 @@ document.addEventListener('DOMContentLoaded', function() {
     updateExamCountdowns();
 
     document.body.addEventListener('click', function(event) {
+        const semesterCard = event.target.closest('.semester-card');
+        if (semesterCard) {
+            if (semesterCard.dataset.semester === '2') {
+                showView(subjectHub);
+            } else {
+                showView(comingSoon);
+            }
+            return;
+        }
+
+        if (event.target.closest('.back-button')) {
+            showView(semesterHub);
+            return;
+        }
+
         const card = event.target.closest('.subject-card');
         if (card && card.dataset.link) {
             window.location.href = card.dataset.link;

--- a/js/insi.js
+++ b/js/insi.js
@@ -1,4 +1,5 @@
 document.addEventListener('DOMContentLoaded', function(){
+    sessionStorage.setItem('selectedSemester', '2');
     const backBtn = document.querySelector('.back-to-hub-btn');
     if (backBtn) backBtn.addEventListener('click', () => { window.location.href = 'index.html'; });
     setupInsi();

--- a/js/mafi2.js
+++ b/js/mafi2.js
@@ -1,4 +1,5 @@
 document.addEventListener('DOMContentLoaded', function(){
+    sessionStorage.setItem('selectedSemester', '2');
     const backBtn = document.querySelector('.back-to-hub-btn');
     if (backBtn) backBtn.addEventListener('click', () => { window.location.href = 'index.html'; });
     setupMafi2();


### PR DESCRIPTION
## Summary
- add main menu to choose semesters 2-5
- display existing subject menu for semester 2 and coming soon for others
- style semester cards and implement view switching

## Testing
- `npm test` *(fails: package.json missing)*

------
https://chatgpt.com/codex/tasks/task_b_6895d02eb8c08322beff6d48f69a00e3