### PR TITLE
Add smooth page transitions

### DIFF
--- a/aud.html
+++ b/aud.html
@@ -58,8 +58,9 @@
         }
     </style>
 </head>
-<body class="text-gray-200">
-<div class="container mx-auto p-4 sm:p-6 lg:p-8 max-w-7xl">
+<body class="text-gray-200" style="background-color:#111827;">
+    <div id="loading-overlay"><div class="spinner"></div></div>
+    <div class="container mx-auto p-4 sm:p-6 lg:p-8 max-w-7xl">
     <div id="aud-app" class="subject-view active">
         <header class="text-center mb-12 relative">
             <button class="back-to-hub-btn absolute top-0 left-0 px-4 py-2 bg-gray-700 text-white rounded-lg hover:bg-gray-600 transition-colors">&larr; Zurück</button>

--- a/aud.html
+++ b/aud.html
@@ -259,6 +259,7 @@
         </main>
     </div>
 </div>
+<script src="js/transition.js"></script>
 <script src="js/aud.js"></script>
 </body>
 </html>

--- a/ccn.html
+++ b/ccn.html
@@ -13,7 +13,8 @@
     <script id="MathJax-script" async src="https://cdn.jsdelivr.net/npm/mathjax@3/es5/tex-mml-chtml.js"></script>
     <link rel="stylesheet" href="css/styles.css">
 </head>
-<body class="text-gray-200">
+<body class="text-gray-200" style="background-color:#111827;">
+    <div id="loading-overlay"><div class="spinner"></div></div>
     <div class="container mx-auto p-4 sm:p-6 lg:p-8 max-w-7xl">
         <div id="ccn-app" class="subject-view active">
             <header class="text-center mb-12 relative">

--- a/ccn.html
+++ b/ccn.html
@@ -369,6 +369,7 @@
         </div>
 
     </div>
+    <script src="js/transition.js"></script>
     <script src="js/ccn.js"></script>
 </body>
 </html>

--- a/css/styles.css
+++ b/css/styles.css
@@ -1,4 +1,7 @@
         /* General Body and Font Styles */
+        html {
+            background-color: #111827; /* Ensure consistent backdrop during fades */
+        }
         body {
             font-family: 'Poppins', sans-serif;
             background-color: #111827; /* Dark blue-gray background */

--- a/css/styles.css
+++ b/css/styles.css
@@ -3,6 +3,14 @@
             font-family: 'Poppins', sans-serif;
             background-color: #111827; /* Dark blue-gray background */
             color: #e5e7eb; /* Light gray text */
+            opacity: 0;
+            transition: opacity 0.3s ease;
+        }
+        body.loaded {
+            opacity: 1;
+        }
+        body.fade-out {
+            opacity: 0;
         }
 
         /* --- Navigation Button Styling (for all subjects) --- */

--- a/css/styles.css
+++ b/css/styles.css
@@ -16,6 +16,36 @@
             opacity: 0;
         }
 
+        /* Loading overlay to prevent bright flash during page transitions */
+        #loading-overlay {
+            position: fixed;
+            top: 0;
+            left: 0;
+            width: 100%;
+            height: 100%;
+            display: flex;
+            align-items: center;
+            justify-content: center;
+            background-color: #111827;
+            z-index: 9999;
+            transition: opacity 0.3s ease;
+        }
+        #loading-overlay.hidden {
+            opacity: 0;
+            pointer-events: none;
+        }
+        #loading-overlay .spinner {
+            width: 40px;
+            height: 40px;
+            border: 4px solid #374151;
+            border-top-color: #0dcaf0;
+            border-radius: 50%;
+            animation: spin 1s linear infinite;
+        }
+        @keyframes spin {
+            to { transform: rotate(360deg); }
+        }
+
         /* --- Navigation Button Styling (for all subjects) --- */
         .nav-button, .mafi-nav-button, .insi-nav-button {
             transition: all 0.3s ease;

--- a/index.html
+++ b/index.html
@@ -13,7 +13,8 @@
     <script id="MathJax-script" async src="https://cdn.jsdelivr.net/npm/mathjax@3/es5/tex-mml-chtml.js"></script>
     <link rel="stylesheet" href="css/styles.css">
 </head>
-<body class="text-gray-200">
+<body class="text-gray-200" style="background-color:#111827;">
+    <div id="loading-overlay"><div class="spinner"></div></div>
     <div class="container mx-auto p-4 sm:p-6 lg:p-8 max-w-7xl">
         <!-- Semester Hub View -->
         <div id="semester-hub" class="subject-view active">

--- a/index.html
+++ b/index.html
@@ -77,6 +77,7 @@
         </div>
     </div>
 
+    <script src="js/transition.js"></script>
     <script src="js/index.js"></script>
 </body>
 </html>

--- a/insi.html
+++ b/insi.html
@@ -321,6 +321,7 @@
         </div>
 
     </div>
+    <script src="js/transition.js"></script>
     <script src="js/insi.js"></script>
 </body>
 </html>

--- a/insi.html
+++ b/insi.html
@@ -13,7 +13,8 @@
     <script id="MathJax-script" async src="https://cdn.jsdelivr.net/npm/mathjax@3/es5/tex-mml-chtml.js"></script>
     <link rel="stylesheet" href="css/styles.css">
 </head>
-<body class="text-gray-200">
+<body class="text-gray-200" style="background-color:#111827;">
+    <div id="loading-overlay"><div class="spinner"></div></div>
     <div class="container mx-auto p-4 sm:p-6 lg:p-8 max-w-7xl">
         <div id="insi-app" class="subject-view active">
             <header class="text-center mb-12 relative">

--- a/js/aud.js
+++ b/js/aud.js
@@ -1,12 +1,6 @@
 document.addEventListener('DOMContentLoaded', function() {
     // --- GENERAL SETUP ---
     sessionStorage.setItem('selectedSemester', '2');
-    const backBtn = document.querySelector('.back-to-hub-btn');
-    if (backBtn) {
-        backBtn.addEventListener('click', () => {
-            window.location.href = 'index.html';
-        });
-    }
 
     if (document.getElementById('aud-app')) {
         setupAud();

--- a/js/ccn.js
+++ b/js/ccn.js
@@ -1,7 +1,5 @@
 document.addEventListener('DOMContentLoaded', function(){
     sessionStorage.setItem('selectedSemester', '2');
-    const backBtn = document.querySelector('.back-to-hub-btn');
-    if (backBtn) backBtn.addEventListener('click', () => { window.location.href = 'index.html'; });
     setupCcn();
 });
     // --- CCN SELECTORS ---

--- a/js/index.js
+++ b/js/index.js
@@ -76,9 +76,5 @@ document.addEventListener('DOMContentLoaded', function() {
             return;
         }
 
-        const card = event.target.closest('.subject-card');
-        if (card && card.dataset.link) {
-            window.location.href = card.dataset.link;
-        }
     });
 });

--- a/js/insi.js
+++ b/js/insi.js
@@ -1,7 +1,5 @@
 document.addEventListener('DOMContentLoaded', function(){
     sessionStorage.setItem('selectedSemester', '2');
-    const backBtn = document.querySelector('.back-to-hub-btn');
-    if (backBtn) backBtn.addEventListener('click', () => { window.location.href = 'index.html'; });
     setupInsi();
 });
 

--- a/js/mafi2.js
+++ b/js/mafi2.js
@@ -1,7 +1,5 @@
 document.addEventListener('DOMContentLoaded', function(){
     sessionStorage.setItem('selectedSemester', '2');
-    const backBtn = document.querySelector('.back-to-hub-btn');
-    if (backBtn) backBtn.addEventListener('click', () => { window.location.href = 'index.html'; });
     setupMafi2();
 });
 

--- a/js/transition.js
+++ b/js/transition.js
@@ -1,5 +1,10 @@
 document.addEventListener('DOMContentLoaded', () => {
-    // fade in on load
+    // fade in on load and hide loading overlay
+    const overlay = document.getElementById('loading-overlay');
+    if (overlay) {
+        overlay.classList.add('hidden');
+        overlay.addEventListener('transitionend', () => overlay.remove());
+    }
     document.body.classList.add('loaded');
 
     // handle forward navigation via data-link

--- a/js/transition.js
+++ b/js/transition.js
@@ -1,0 +1,30 @@
+document.addEventListener('DOMContentLoaded', () => {
+    // fade in on load
+    document.body.classList.add('loaded');
+
+    // handle forward navigation via data-link
+    document.querySelectorAll('[data-link]').forEach(el => {
+        el.addEventListener('click', e => {
+            const url = el.getAttribute('data-link');
+            if (url) {
+                e.preventDefault();
+                document.body.classList.add('fade-out');
+                setTimeout(() => {
+                    window.location.href = url;
+                }, 300);
+            }
+        });
+    });
+
+    // handle back button to hub
+    const backBtn = document.querySelector('.back-to-hub-btn');
+    if (backBtn) {
+        backBtn.addEventListener('click', e => {
+            e.preventDefault();
+            document.body.classList.add('fade-out');
+            setTimeout(() => {
+                window.location.href = 'index.html';
+            }, 300);
+        });
+    }
+});

--- a/mafi2.html
+++ b/mafi2.html
@@ -268,6 +268,7 @@
         </div>
 
     </div>
+    <script src="js/transition.js"></script>
     <script src="js/mafi2.js"></script>
 </body>
 </html>

--- a/mafi2.html
+++ b/mafi2.html
@@ -13,7 +13,8 @@
     <script id="MathJax-script" async src="https://cdn.jsdelivr.net/npm/mathjax@3/es5/tex-mml-chtml.js"></script>
     <link rel="stylesheet" href="css/styles.css">
 </head>
-<body class="text-gray-200">
+<body class="text-gray-200" style="background-color:#111827;">
+    <div id="loading-overlay"><div class="spinner"></div></div>
     <div class="container mx-auto p-4 sm:p-6 lg:p-8 max-w-7xl">
         <div id="mafi2-app" class="subject-view active">
              <header class="text-center mb-12 relative">


### PR DESCRIPTION
## Summary
- add fade-in/out effect for navigation using shared transition script
- simplify subject scripts and include transition script across pages
- set up CSS to support page opacity transitions

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_b_6895d41df4b0832295a00ca1bae820bb