### PR TITLE
Load subjects dynamically without page reload

### DIFF
--- a/index.html
+++ b/index.html
@@ -75,6 +75,9 @@
             <h1 class="text-5xl font-bold text-white">Coming Soon</h1>
             <p class="text-xl text-gray-400 mt-2">Inhalt für dieses Semester ist noch in Arbeit.</p>
         </div>
+
+        <!-- Dynamically loaded subject content -->
+        <div id="dynamic-content" class="subject-view"></div>
     </div>
 
     <script src="js/index.js"></script>

--- a/js/aud.js
+++ b/js/aud.js
@@ -1,17 +1,15 @@
-document.addEventListener('DOMContentLoaded', function() {
-    // --- GENERAL SETUP ---
-    sessionStorage.setItem('selectedSemester', '2');
-    const backBtn = document.querySelector('.back-to-hub-btn');
-    if (backBtn) {
-        backBtn.addEventListener('click', () => {
-            window.location.href = 'index.html';
-        });
-    }
+// --- GENERAL SETUP ---
+sessionStorage.setItem('selectedSemester', '2');
+const backBtn = document.querySelector('.back-to-hub-btn');
+if (backBtn) {
+    backBtn.addEventListener('click', () => {
+        window.dispatchEvent(new CustomEvent('navigate-back'));
+    });
+}
 
-    if (document.getElementById('aud-app')) {
-        setupAud();
-    }
-});
+if (document.getElementById('aud-app')) {
+    setupAud();
+}
 
 
 function setupAud() {

--- a/js/aud.js
+++ b/js/aud.js
@@ -1,3 +1,4 @@
+(() => {
 // --- GENERAL SETUP ---
 sessionStorage.setItem('selectedSemester', '2');
 const backBtn = document.querySelector('.back-to-hub-btn');
@@ -1076,3 +1077,4 @@ function setupAud() {
     if(generateAudExercisesBtn) generateAudExercisesBtn.addEventListener('click', generateAudExercises);
     generateAudExercises();
 }
+})();

--- a/js/ccn.js
+++ b/js/ccn.js
@@ -1,3 +1,4 @@
+(() => {
 sessionStorage.setItem('selectedSemester', '2');
 const backBtn = document.querySelector('.back-to-hub-btn');
 if (backBtn) backBtn.addEventListener('click', () => { window.dispatchEvent(new CustomEvent('navigate-back')); });
@@ -940,5 +941,6 @@ if (backBtn) backBtn.addEventListener('click', () => { window.dispatchEvent(new 
 }
 
 setupCcn();
+})();
 
 

--- a/js/ccn.js
+++ b/js/ccn.js
@@ -1,10 +1,8 @@
-document.addEventListener('DOMContentLoaded', function(){
-    sessionStorage.setItem('selectedSemester', '2');
-    const backBtn = document.querySelector('.back-to-hub-btn');
-    if (backBtn) backBtn.addEventListener('click', () => { window.location.href = 'index.html'; });
-    setupCcn();
-});
-    // --- CCN SELECTORS ---
+sessionStorage.setItem('selectedSemester', '2');
+const backBtn = document.querySelector('.back-to-hub-btn');
+if (backBtn) backBtn.addEventListener('click', () => { window.dispatchEvent(new CustomEvent('navigate-back')); });
+
+// --- CCN SELECTORS ---
     const navButtons = document.querySelectorAll('.nav-button');
     const contentSections = document.querySelectorAll('.content-section');
     const protocolSelectorButtons = document.querySelectorAll('#protocol-selector button');
@@ -936,9 +934,11 @@ document.addEventListener('DOMContentLoaded', function(){
             }
         });
 
-        if (bestMatch) {
-            bestMatch.classList.add('highlight');
-        }
+    if (bestMatch) {
+        bestMatch.classList.add('highlight');
     }
+}
+
+setupCcn();
 
 

--- a/js/insi.js
+++ b/js/insi.js
@@ -1,9 +1,6 @@
-document.addEventListener('DOMContentLoaded', function(){
-    sessionStorage.setItem('selectedSemester', '2');
-    const backBtn = document.querySelector('.back-to-hub-btn');
-    if (backBtn) backBtn.addEventListener('click', () => { window.location.href = 'index.html'; });
-    setupInsi();
-});
+sessionStorage.setItem('selectedSemester', '2');
+const backBtn = document.querySelector('.back-to-hub-btn');
+if (backBtn) backBtn.addEventListener('click', () => { window.dispatchEvent(new CustomEvent('navigate-back')); });
 
 const insiNavButtons = document.querySelectorAll('.insi-nav-button');
 const insiContentSections = document.querySelectorAll('.insi-content-section');
@@ -298,4 +295,6 @@ const exercisesContainer = document.getElementById('exercises-container');
             MathJax.typesetPromise(Array.from(exercisesContainer.children));
         }
     }
+
+setupInsi();
     

--- a/js/insi.js
+++ b/js/insi.js
@@ -1,3 +1,4 @@
+(() => {
 sessionStorage.setItem('selectedSemester', '2');
 const backBtn = document.querySelector('.back-to-hub-btn');
 if (backBtn) backBtn.addEventListener('click', () => { window.dispatchEvent(new CustomEvent('navigate-back')); });
@@ -297,4 +298,4 @@ const exercisesContainer = document.getElementById('exercises-container');
     }
 
 setupInsi();
-    
+})();

--- a/js/mafi2.js
+++ b/js/mafi2.js
@@ -1,9 +1,7 @@
-document.addEventListener('DOMContentLoaded', function(){
-    sessionStorage.setItem('selectedSemester', '2');
-    const backBtn = document.querySelector('.back-to-hub-btn');
-    if (backBtn) backBtn.addEventListener('click', () => { window.location.href = 'index.html'; });
-    setupMafi2();
-});
+sessionStorage.setItem('selectedSemester', '2');
+const backBtn = document.querySelector('.back-to-hub-btn');
+if (backBtn) backBtn.addEventListener('click', () => { window.dispatchEvent(new CustomEvent('navigate-back')); });
+
 
     const simpleMathParser = {
         parse: function(expr) {
@@ -485,6 +483,8 @@ const eulerAngleSlider = document.getElementById('euler-angle-slider');
             });
         });
 
-        if (window.MathJax) MathJax.typesetPromise([container]);
-    }
+    if (window.MathJax) MathJax.typesetPromise([container]);
+}
+
+setupMafi2();
 

--- a/js/mafi2.js
+++ b/js/mafi2.js
@@ -1,3 +1,4 @@
+(() => {
 sessionStorage.setItem('selectedSemester', '2');
 const backBtn = document.querySelector('.back-to-hub-btn');
 if (backBtn) backBtn.addEventListener('click', () => { window.dispatchEvent(new CustomEvent('navigate-back')); });
@@ -487,4 +488,5 @@ const eulerAngleSlider = document.getElementById('euler-angle-slider');
 }
 
 setupMafi2();
+})();
 


### PR DESCRIPTION
## Summary
- Load subject pages into index dynamically via fetch and a dedicated container, removing the need for window.location navigation.
- Introduce a custom `navigate-back` event to return to the subject hub without reloading.
- Update subject scripts (CCN, Mafi2, Insi, AuD) to initialize immediately and use the new back-event instead of `window.location.href`.

## Testing
- `npm test` *(fails: Could not read package.json)*


------
https://chatgpt.com/codex/tasks/task_b_6895e8a04d748322a294c43f557b9fd5