### PR TITLE
Fix missing graph visualization styles for AuD

### DIFF
--- a/aud.html
+++ b/aud.html
@@ -11,52 +11,6 @@
     <link rel="icon" type="image/x-icon" href="https://cdn-icons-png.flaticon.com/512/1599/1599145.png">
     <script id="MathJax-script" async src="https://cdn.jsdelivr.net/npm/mathjax@3/es5/tex-mml-chtml.js"></script>
     <link rel="stylesheet" href="css/styles.css">
-    <style>
-        .bar { transition: all 0.3s ease-in-out; }
-        .code-block { background-color: #2d3748; border-radius: 0.5rem; padding: 1rem; font-family: 'Courier New', Courier, monospace; white-space: pre; }
-        .solution-code { background-color: #1a202c; border-left: 4px solid #0891b2; padding: 1rem; margin-top: 1rem; border-radius: 0.5rem; font-family: 'Courier New', Courier, monospace; white-space: pre; }
-        /* --- Graph Visualizer Styles --- */
-        .graph-node {
-            transition: all 0.3s ease;
-            cursor: pointer;
-        }
-        .graph-node circle {
-            stroke-width: 2px;
-            stroke: #0891b2;
-            fill: #1f2937;
-        }
-        .graph-node text {
-            fill: #e5e7eb;
-            font-size: 14px;
-            font-weight: bold;
-            pointer-events: none;
-        }
-        .graph-node.visited circle {
-            fill: #2dd4bf; /* teal */
-            stroke: #14b8a6;
-        }
-        .graph-node.active circle {
-            stroke: #facc15; /* yellow */
-            stroke-width: 4px;
-        }
-        .graph-edge {
-            stroke: #4b5563; /* gray */
-            stroke-width: 2px;
-            transition: all 0.3s ease;
-        }
-        .graph-edge.highlighted {
-            stroke: #fb923c; /* orange */
-            stroke-width: 4px;
-        }
-        .graph-edge.mst {
-            stroke: #2dd4bf; /* teal */
-            stroke-width: 4px;
-        }
-        .edge-weight {
-            fill: #d1d5db;
-            font-size: 12px;
-        }
-    </style>
 </head>
 <body class="text-gray-200">
 <div class="container mx-auto p-4 sm:p-6 lg:p-8 max-w-7xl">

--- a/css/styles.css
+++ b/css/styles.css
@@ -191,3 +191,66 @@
             color: white;
         }
 
+        /* --- AuD Specific Styles --- */
+        .bar {
+            transition: all 0.3s ease-in-out;
+        }
+        .code-block {
+            background-color: #2d3748;
+            border-radius: 0.5rem;
+            padding: 1rem;
+            font-family: 'Courier New', Courier, monospace;
+            white-space: pre;
+        }
+        .solution-code {
+            background-color: #1a202c;
+            border-left: 4px solid #0891b2;
+            padding: 1rem;
+            margin-top: 1rem;
+            border-radius: 0.5rem;
+            font-family: 'Courier New', Courier, monospace;
+            white-space: pre;
+        }
+
+        /* --- Graph Visualizer Styles --- */
+        .graph-node {
+            transition: all 0.3s ease;
+            cursor: pointer;
+        }
+        .graph-node circle {
+            stroke-width: 2px;
+            stroke: #0891b2;
+            fill: #1f2937;
+        }
+        .graph-node text {
+            fill: #e5e7eb;
+            font-size: 14px;
+            font-weight: bold;
+            pointer-events: none;
+        }
+        .graph-node.visited circle {
+            fill: #2dd4bf; /* teal */
+            stroke: #14b8a6;
+        }
+        .graph-node.active circle {
+            stroke: #facc15; /* yellow */
+            stroke-width: 4px;
+        }
+        .graph-edge {
+            stroke: #4b5563; /* gray */
+            stroke-width: 2px;
+            transition: all 0.3s ease;
+        }
+        .graph-edge.highlighted {
+            stroke: #fb923c; /* orange */
+            stroke-width: 4px;
+        }
+        .graph-edge.mst {
+            stroke: #2dd4bf; /* teal */
+            stroke-width: 4px;
+        }
+        .edge-weight {
+            fill: #d1d5db;
+            font-size: 12px;
+        }
+

--- a/js/aud.js
+++ b/js/aud.js
@@ -603,11 +603,17 @@ function setupAud() {
                 circle.setAttribute('cx', node.x);
                 circle.setAttribute('cy', node.y);
                 circle.setAttribute('r', 15);
+                circle.setAttribute('fill', '#1f2937');
+                circle.setAttribute('stroke', '#0891b2');
+                circle.setAttribute('stroke-width', 2);
 
                 const text = document.createElementNS("http://www.w3.org/2000/svg", "text");
                 text.setAttribute('x', node.x);
                 text.setAttribute('y', node.y + 5);
                 text.setAttribute('text-anchor', 'middle');
+                text.setAttribute('fill', '#e5e7eb');
+                text.setAttribute('font-size', '14');
+                text.setAttribute('font-weight', 'bold');
                 text.textContent = node.id;
 
                 g.appendChild(circle);


### PR DESCRIPTION
## Summary
- Move AuD graph visualization and helper styles into global stylesheet so Dijkstra and Kruskal render correctly
- Remove redundant inline style block from `aud.html`

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_b_689afcab8f988322aeb28351cab5636a