### PR TITLE
Add exam date request dialog

### DIFF
--- a/index.html
+++ b/index.html
@@ -33,6 +33,18 @@
             </button>
         </div>
     </div>
+
+    <div id="requestDateDialog" class="dialog-overlay hidden">
+        <div class="dialog-box">
+            <div class="dialog-header">Datum anfragen</div>
+            <div class="dialog-content">
+                <p>Bitte gewünschtes Datum für <span id="request-subject"></span> angeben:</p>
+                <input type="date" id="request-date-input" class="mt-2 p-2 w-full border rounded">
+            </div>
+            <button class="dialog-button" id="request-date-send">Senden</button>
+            <button class="dialog-button mt-2" id="request-date-cancel">Abbrechen</button>
+        </div>
+    </div>
     <div class="container mx-auto p-4 sm:p-6 lg:p-8 max-w-7xl">
         <!-- Semester Hub View -->
         <div id="semester-hub" class="subject-view active pt-16">
@@ -67,22 +79,34 @@
                 <div class="subject-card card p-8 rounded-2xl shadow-2xl text-center cursor-pointer" data-link="ccn.html">
                     <h2 class="text-3xl font-bold text-cyan-400">CCN</h2>
                     <p class="text-gray-300 mt-2">Computer & Communication Networks</p>
-                    <p class="text-gray-400 mt-4 exam-countdown" data-subject-id="ccn"></p>
+                    <div class="mt-4 flex items-center justify-center space-x-2">
+                        <span class="text-gray-400 exam-date" data-subject-id="ccn"></span>
+                        <button class="request-date-button nav-button px-2 py-1 rounded text-sm" data-subject-id="ccn">Datum anfragen</button>
+                    </div>
                 </div>
                 <div class="subject-card card p-8 rounded-2xl shadow-2xl text-center cursor-pointer" data-link="mafi2.html">
                     <h2 class="text-3xl font-bold text-cyan-400">Mafi 2</h2>
                     <p class="text-gray-300 mt-2">Mathe für Informatiker 2</p>
-                    <p class="text-gray-400 mt-4 exam-countdown" data-subject-id="mafi2"></p>
+                    <div class="mt-4 flex items-center justify-center space-x-2">
+                        <span class="text-gray-400 exam-date" data-subject-id="mafi2"></span>
+                        <button class="request-date-button nav-button px-2 py-1 rounded text-sm" data-subject-id="mafi2">Datum anfragen</button>
+                    </div>
                 </div>
                 <div class="subject-card card p-8 rounded-2xl shadow-2xl text-center cursor-pointer" data-link="aud.html">
                     <h2 class="text-3xl font-bold text-cyan-400">AuD</h2>
                     <p class="text-gray-300 mt-2">Algorithmen und Datenstrukturen</p>
-                    <p class="text-gray-400 mt-4 exam-countdown" data-subject-id="aud"></p>
+                    <div class="mt-4 flex items-center justify-center space-x-2">
+                        <span class="text-gray-400 exam-date" data-subject-id="aud"></span>
+                        <button class="request-date-button nav-button px-2 py-1 rounded text-sm" data-subject-id="aud">Datum anfragen</button>
+                    </div>
                 </div>
                 <div class="subject-card card p-8 rounded-2xl shadow-2xl text-center cursor-pointer" data-link="insi.html">
                     <h2 class="text-3xl font-bold text-cyan-400">Insi</h2>
                     <p class="text-gray-300 mt-2">Informationssicherheit</p>
-                    <p class="text-gray-400 mt-4 exam-countdown" data-subject-id="insi"></p>
+                    <div class="mt-4 flex items-center justify-center space-x-2">
+                        <span class="text-gray-400 exam-date" data-subject-id="insi"></span>
+                        <button class="request-date-button nav-button px-2 py-1 rounded text-sm" data-subject-id="insi">Datum anfragen</button>
+                    </div>
                 </div>
             </div>
         </div>

--- a/js/index.js
+++ b/js/index.js
@@ -3,7 +3,7 @@ document.addEventListener('DOMContentLoaded', function() {
     const examDates = {
         'ccn': new Date(2025, 7, 4),
         'mafi2': new Date(2025, 7, 7),
-        'insi': new Date(2025, 7, 22),
+        'insi': null,
         'aud': new Date(2025, 7, 14)
     };
 
@@ -24,40 +24,51 @@ document.addEventListener('DOMContentLoaded', function() {
         showView(comingSoon);
     }
 
-    function updateExamCountdowns() {
-        const countdownElements = document.querySelectorAll('.exam-countdown');
-        const today = new Date();
-        today.setHours(0, 0, 0, 0);
-
-        countdownElements.forEach(el => {
+    function updateExamDates() {
+        const dateElements = document.querySelectorAll('.exam-date');
+        dateElements.forEach(el => {
             const subjectId = el.dataset.subjectId;
             const examDate = examDates[subjectId];
-
             if (examDate) {
-                const diffTime = examDate.getTime() - today.getTime();
-                const diffDays = Math.ceil(diffTime / (1000 * 60 * 60 * 24));
-
-                if (diffDays < 0) {
-                    el.textContent = "Klausur vorbei";
-                } else if (diffDays === 0) {
-                    el.textContent = "Heute!";
-                    el.classList.add('text-red-500', 'font-bold');
-                } else if (diffDays === 1) {
-                    el.textContent = "Morgen!";
-                    el.classList.add('text-red-500', 'font-bold');
-                } else {
-                    el.textContent = `${diffDays} Tage verbleibend`;
-                    if (diffDays <= 7) {
-                        el.classList.add('text-red-500', 'font-bold');
-                    } else {
-                        el.classList.remove('text-red-500', 'font-bold');
-                    }
-                }
+                el.textContent = examDate.toLocaleDateString('de-DE');
+            } else {
+                el.textContent = 'kein datum angegeben';
             }
         });
     }
 
-    updateExamCountdowns();
+    updateExamDates();
+
+    function openRequestDateDialog(subjectId) {
+        const dialog = document.getElementById('requestDateDialog');
+        dialog.classList.remove('hidden');
+        document.body.style.overflow = 'hidden';
+        dialog.dataset.subjectId = subjectId;
+        document.getElementById('request-subject').textContent = subjectId.toUpperCase();
+        document.getElementById('request-date-input').value = '';
+    }
+
+    function closeRequestDateDialog() {
+        document.getElementById('requestDateDialog').classList.add('hidden');
+        document.body.style.overflow = '';
+    }
+
+    document.getElementById('request-date-send').addEventListener('click', function() {
+        const dialog = document.getElementById('requestDateDialog');
+        const subjectId = dialog.dataset.subjectId;
+        const desiredDate = document.getElementById('request-date-input').value;
+        console.log(`Anfrage für ${subjectId}: ${desiredDate}`);
+        // TODO: Mail an Admin mit gewünschtem Datum senden
+        closeRequestDateDialog();
+    });
+
+    document.getElementById('request-date-cancel').addEventListener('click', closeRequestDateDialog);
+
+    document.getElementById('requestDateDialog').addEventListener('click', function(e) {
+        if (e.target === this) {
+            closeRequestDateDialog();
+        }
+    });
 
     function loadPage(url) {
         fetch(url)
@@ -122,6 +133,12 @@ document.addEventListener('DOMContentLoaded', function() {
             return;
         }
 
+        const requestBtn = event.target.closest('.request-date-button');
+        if (requestBtn) {
+            openRequestDateDialog(requestBtn.dataset.subjectId);
+            return;
+        }
+
         const card = event.target.closest('.subject-card');
         if (card && card.dataset.link) {
             loadPage(card.dataset.link);
@@ -168,7 +185,12 @@ document.getElementById('firstVisitDialog').addEventListener('click', function(e
 });
 
 document.addEventListener('keydown', function(e) {
-    if (e.key === 'Escape' && !document.getElementById('firstVisitDialog').classList.contains('hidden')) {
-        closeFirstVisitDialog();
+    if (e.key === 'Escape') {
+        if (!document.getElementById('firstVisitDialog').classList.contains('hidden')) {
+            closeFirstVisitDialog();
+        }
+        if (!document.getElementById('requestDateDialog').classList.contains('hidden')) {
+            closeRequestDateDialog();
+        }
     }
 });


### PR DESCRIPTION
## Summary
- display exam dates or placeholder text for each subject with a button to request a date
- add dialog to submit desired exam date (email sending still TODO)

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_b_68aef3e0b1c883228dc434acec19cbd2